### PR TITLE
Add lates versions of common packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,31 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
+
+beautifulsoup4 = "*"
+bokeh = "*"
+cloudpickle = "*"
+cython = "*"
+dask = "*"
+dill = "*"
+distributed = "*"
+h5py = "*"
+ipywidgets = "*"
+jupyter-bokeh = "*"
+jupyter-tensorboard = "*"
+matplotlib = "*"
+pandas = "*"
+plotly = "*"
+pyarrow = "*"
+s3fs = "*"
+scikit-image = "*"
+scikit-learn = "*"
+scipy = "*"
+seaborn = "*"
+sqlalchemy = "*"
+statsmodels = "*"
 torch  = "*"
+torchvision= "*"
 
 [requires]
 python_version = "3.6"


### PR DESCRIPTION
Due to `torch` not being available yet in Thamos advise, I've put in the latest versions of all packages. 